### PR TITLE
[fix] correct api address

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -5,11 +5,11 @@ const env = process.env.NODE_ENV || 'production'
 
 const EnvConfig = {
   development: {
-    baseApi: '/api/admin',
+    baseApi: 'https://api-dev.bitrxc.com/admin',
     mockApi: 'http://rap2api.taobao.org/app/mock/291194/api/admin'
   },
   production: {
-    baseApi: '/admin',
+    baseApi: 'https://api.bitrxc.com/admin',
     mockApi: 'http://rap2api.taobao.org/app/mock/291194/api/admin'
   }
 }


### PR DESCRIPTION
Due to omitted domain name in api address, the client send its request to wrong destination. This patch change it to correct address.

由于请求地址错误，这个客户端将请求发送到了错误的位置。以下补丁修正了请求地址。